### PR TITLE
cinny artist platform integration

### DIFF
--- a/src/app/components/message/layout/Bubble.tsx
+++ b/src/app/components/message/layout/Bubble.tsx
@@ -7,11 +7,11 @@ type BubbleLayoutProps = {
 };
 
 export const BubbleLayout = as<'div', BubbleLayoutProps>(({ before, children, ...props }, ref) => (
-  <Box gap="300" {...props} ref={ref}>
+  <Box gap="300" {...props} ref={ref} className={'room_message_zed'}>
     <Box className={css.BubbleBefore} shrink="No">
       {before}
     </Box>
-    <Box className={css.BubbleContent} direction="Column">
+    <Box className={`${css.BubbleContent} room_message_den`} direction="Column">
       {children}
     </Box>
   </Box>

--- a/src/app/components/message/layout/Compact.tsx
+++ b/src/app/components/message/layout/Compact.tsx
@@ -8,7 +8,7 @@ type CompactLayoutProps = {
 
 export const CompactLayout = as<'div', CompactLayoutProps>(
   ({ before, children, ...props }, ref) => (
-    <Box gap="200" {...props} ref={ref}>
+    <Box gap="200" {...props} ref={ref} className={'room_message_zed'}>
       <Box className={css.CompactHeader} gap="200" shrink="No">
         {before}
       </Box>

--- a/src/app/components/message/layout/Modern.tsx
+++ b/src/app/components/message/layout/Modern.tsx
@@ -11,8 +11,8 @@ export const ModernLayout = as<'div', ModernLayoutProps>(({ before, children, ..
     <Box className={css.ModernBefore} shrink="No">
       {before}
     </Box>
-    <Box grow="Yes" direction="Column">
+    <div className={`room_message_modern`}>
       {children}
-    </Box>
+    </div>
   </Box>
 ));

--- a/src/app/organisms/room/RoomInput.tsx
+++ b/src/app/organisms/room/RoomInput.tsx
@@ -386,7 +386,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     };
 
     return (
-      <div ref={ref}>
+      <div ref={ref} className='app_roomInput'>
         {selectedFiles.length > 0 && (
           <UploadBoard
             header={

--- a/src/app/organisms/room/RoomViewHeader.jsx
+++ b/src/app/organisms/room/RoomViewHeader.jsx
@@ -19,13 +19,15 @@ import BackArrowIC from '../../../../public/res/ic/outlined/chevron-left.svg';
 
 import { useForceUpdate } from '../../hooks/useForceUpdate';
 import BackButton from '../../../momentify/BackButton';
+import Avatar from '../../atoms/avatar/Avatar';
+import colorMXID from '../../../util/colorMXID';
 
 function RoomViewHeader({ roomId }) {
   const [, forceUpdate] = useForceUpdate();
   const mx = initMatrix.matrixClient;
   const isDM = initMatrix.roomList.directs.has(roomId);
   const room = mx.getRoom(roomId);
-  let avatarSrc = room.getAvatarUrl(mx.baseUrl, 36, 36, 'crop');
+  let avatarSrc = room.getAvatarUrl(mx.baseUrl, 50, 50, 'crop') ??  room.room_avatar
   avatarSrc = isDM
     ? room.getAvatarFallbackMember()?.getAvatarUrl(mx.baseUrl, 36, 36, 'crop')
     : avatarSrc;

--- a/src/app/organisms/room/message/Message.tsx
+++ b/src/app/organisms/room/message/Message.tsx
@@ -786,6 +786,7 @@ export const Message = as<'div', MessageProps>(
                     variant="SurfaceVariant"
                     size="300"
                     radii="300"
+                    className='room_message_edit_btn'
                   >
                     <Icon src={Icons.Pencil} size="100" />
                   </IconButton>
@@ -935,18 +936,18 @@ export const Message = as<'div', MessageProps>(
           </div>
         )}
         {messageLayout === 1 && (
-          <CompactLayout before={headerJSX} onContextMenu={handleContextMenu}>
+          <CompactLayout before={headerJSX} onContextMenu={handleContextMenu} className={'room_message_block_compact'}>
             {msgContentJSX}
           </CompactLayout>
         )}
         {messageLayout === 2 && (
-          <BubbleLayout before={avatarJSX} onContextMenu={handleContextMenu}>
+          <BubbleLayout before={avatarJSX} onContextMenu={handleContextMenu} className={'room_message_block_bubble'}>
             {headerJSX}
             {msgContentJSX}
           </BubbleLayout>
         )}
         {messageLayout !== 1 && messageLayout !== 2 && (
-          <ModernLayout before={avatarJSX} onContextMenu={handleContextMenu}>
+          <ModernLayout before={avatarJSX} onContextMenu={handleContextMenu} className={'room_message_block_modern'}>
             {headerJSX}
             {msgContentJSX}
           </ModernLayout>

--- a/src/app/templates/client/ClientContent.jsx
+++ b/src/app/templates/client/ClientContent.jsx
@@ -9,7 +9,7 @@ import Welcome from '../../organisms/loading-room/LoadingRoom';
 // import Welcome from '../../organisms/welcome/Welcome';
 import { RoomBaseView } from '../../organisms/room/Room';
 import * as roomActions from '../../../client/action/room';
-import { extractRoomIDFromURL } from '../../utils/RoomGetter';
+import { extractRoomIDFromURL, extractRoomIDFromURLWithoutParam } from '../../utils/RoomGetter';
 import ErrorPage from '../../../momentify/ErrorPage';
 import { getRoomByRoomAddress } from '../../../util/matrixUtil';
 import { getSecret } from '../../../client/state/auth';
@@ -27,7 +27,7 @@ export function ClientContent() {
   const mx = initMatrix.matrixClient;
 
   useEffect(() => {
-    const roomIDParam = extractRoomIDFromURL(window.location.href) ?? '';
+    const roomIDParam = extractRoomIDFromURL(window.location.href) ?? extractRoomIDFromURLWithoutParam(window.location.href) ?? '';
     return () => {
       getRoomByRoomAddress(getSecret(cons.secretKey.ACCESS_TOKEN), roomIDParam ?? null)
         .then(dbRoom => {

--- a/src/app/utils/RoomGetter.js
+++ b/src/app/utils/RoomGetter.js
@@ -3,3 +3,15 @@ export const extractRoomIDFromURL = (url) => {
 	const roomID = urlParams.get('roomID');
 	return roomID;
 };
+
+export const extractRoomIDFromURLWithoutParam = (url) => {
+	const _url = new URL(url);
+
+	// Split the pathname by '/' and filter out empty strings
+	const pathSegments = _url.pathname.split('/').filter(segment => segment.length > 0);
+
+	// Get the last segment
+	const lastSegment = pathSegments.pop();
+
+	return lastSegment;
+};

--- a/src/momentify/BackButton.jsx
+++ b/src/momentify/BackButton.jsx
@@ -29,7 +29,7 @@ export default function BackButton({className, ...props}) {
     //  style={{...Button}}
     // />
 
-    <IconButton variant="Surface" size="300" onClick={handleOnClick} style={{...Button}} {...props}>
+    <IconButton className={className} variant="Surface" size="300" onClick={handleOnClick} style={{...Button}} {...props}>
       <Icon src={Icons.ArrowLeft} />
     </IconButton>
   )

--- a/src/momentify/federation-util.js
+++ b/src/momentify/federation-util.js
@@ -1,0 +1,4 @@
+
+export function getURLDomain () {
+  return window.location.href
+}

--- a/src/util/matrixUtil.js
+++ b/src/util/matrixUtil.js
@@ -253,3 +253,23 @@ export async function getRoomByRoomAddress(accessToken, roomAddress) {
       console.error({ getRoomByRoomAddressError: err });
   }
 }
+
+export async function setJoinedRoom(roomId, userMxId) {
+  if(!roomId || !userMxId) return false
+  try {      
+      const result = await fetch(`${import.meta.env.VITE_API_URL}/matrix/room/join`, {
+          method: "POST",
+          headers: {
+          "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            room_id: roomId,
+            user_mx_id: userMxId
+          })
+      });
+
+      return result.json();
+  } catch (err) {
+      console.error({ setJoinedRoomError: err });
+  }
+}


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
This PR primarily focuses on enhancing the application by adding new functions and classes to various components. The most significant changes include:
- Addition of new functions to extract room ID from URL without parameters, get URL domain, and set joined room.
- Addition of new classes to `Box`, `div`, `IconButton`, `CompactLayout`, `BubbleLayout`, and `ModernLayout` components.
- Update of `avatarSrc` in `RoomViewHeader.jsx` to get the avatar URL with different dimensions and fallback to `room.room_avatar`.
- Update of `roomIDParam` in `ClientContent.jsx` to use `extractRoomIDFromURLWithoutParam` function when `extractRoomIDFromURL` returns null.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>RoomGetter.js</strong><dd><code>Addition of new function to extract room ID from URL without parameters</code></dd></summary>
<hr>

src/app/utils/RoomGetter.js
- Added a new function `extractRoomIDFromURLWithoutParam` to extract <br>  room ID from URL without parameters.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-851aecc3610e94355e0e6d18e82efeb0e3dc81e5889011bcaafa3be50a9d059e">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>federation-util.js</strong><dd><code>Addition of new function to get URL domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/momentify/federation-util.js
- Added a new function `getURLDomain` to get the current URL domain.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-b7a6574222d80e8ac0c4d63e9760e8a65a5e05627aa9821f159e06e8ea61ee2d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>matrixUtil.js</strong><dd><code>Addition of new function to set joined room</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/util/matrixUtil.js
- Added a new function `setJoinedRoom` to set the joined room.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-f2e05d0b65c037b2c2f3b5f00f34c62a694df9e205076685a9343e8cae7ae533">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Bubble.tsx</strong><dd><code>Addition of new classes to Box component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/components/message/layout/Bubble.tsx
- Added a new class `room_message_zed` to the `Box` component.
- Added a new class `room_message_den` to the `Box` component.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-cdc61fbccfbdac9b9ac9cd00a1d93615babb0caee13a7f4967cb29f4da030e7d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Compact.tsx</strong><dd><code>Addition of new class to Box component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/components/message/layout/Compact.tsx
- Added a new class `room_message_zed` to the `Box` component.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-b205dc4b6a76ec3d31a304ceb27515082169c7a10329e1884c2f67c02d5bc9fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Modern.tsx</strong><dd><code>Component replacement and addition of new class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/components/message/layout/Modern.tsx
- Replaced `Box` component with `div` and added a new class <br>  `room_message_modern`.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-aae3f432b0c94479746241f4480628b2789347d5a1a57334131926ca3a867f6d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RoomInput.tsx</strong><dd><code>Addition of new class to div element</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/organisms/room/RoomInput.tsx
- Added a new class `app_roomInput` to the `div` element.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-99e565b1c19cde2d8f2a7a79f55885b831806c13c440e21e51915211a6021a17">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Message.tsx</strong><dd><code>Addition of new classes to various components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/organisms/room/message/Message.tsx
- Added new classes to `CompactLayout`, `BubbleLayout`, and `<br>  ``ModernLayout` <br>  components.
- Added a new class `room_message_edit_btn` to the `IconButton` <br>  component.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-bf7796cfa1d50c9b03513358a5363fe7459b9f78205a23a9e2bc7f4816c1f8f7">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RoomViewHeader.jsx</strong><dd><code>Update avatar source and import new modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/organisms/room/RoomViewHeader.jsx
- Imported `Avatar` and `colorMXID` modules.
- Updated the `avatarSrc` to get the avatar URL with different <br>  dimensions and fallback to `room.room_avatar`.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-bf17b451c3dcfb81c511e91fa2a9c337472f8bc50fe10445e1d28333f543e776">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ClientContent.jsx</strong><dd><code>Update room ID extraction and import new function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/templates/client/ClientContent.jsx
- Imported `extractRoomIDFromURLWithoutParam` function.
- Updated `roomIDParam` to use `extractRoomIDFromURLWithoutParam` <br>  function when `extractRoomIDFromURL` returns null.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-c2079f27bf65b052c2aea8b6ed3dcaa45958144c63a81f6a629840c5a98a35ae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BackButton.jsx</strong><dd><code>Addition of className prop to IconButton component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/momentify/BackButton.jsx
- Added `className` prop to `IconButton` component.
    </details>
  </td>
  <td><a href="https://github.com/Momentify/momentify.cinny/pull/38/files#diff-694a234f3a871abcde87e8750486e7f47f33d8f9d9809e2f9ea901404de7be0e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
