### PR TITLE
[MOM-1982] Update code for backdrop element for emoji board, do not display member UUID in autocomplete mentions UI

### DIFF
--- a/src/app/components/editor/autocomplete/UserMentionAutocomplete.tsx
+++ b/src/app/components/editor/autocomplete/UserMentionAutocomplete.tsx
@@ -161,7 +161,7 @@ export function UserMentionAutocomplete({
               }
               onClick={() => handleAutocomplete(roomMember.userId, getName(roomMember))}
               after={
-                <Text size="T200" priority="300" truncate>
+                <Text size="T200" priority="300" truncate style={{ display: 'none' }}>
                   {roomMember.userId}
                 </Text>
               }

--- a/src/app/organisms/room/message/Message.tsx
+++ b/src/app/organisms/room/message/Message.tsx
@@ -33,6 +33,7 @@ import React, {
   useLayoutEffect,
   KeyboardEventHandler,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { isKeyHotkey } from 'is-hotkey';
 import FocusTrap from 'focus-trap-react';
 import { useHover, useFocusWithin } from 'react-aria';
@@ -615,6 +616,7 @@ export const Message = as<'div', MessageProps>(
     const { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setHover });
     const [menu, setMenu] = useState(false);
     const [emojiBoard, setEmojiBoard] = useState(false);
+    const [backdropEl, setBackdropEl] = useState<React.ReactNode | null>(null);
 
     // TODO: handler missing profile import ImageBrokenSVG from '../../../../public/res/svg/image-broken.svg';
     const senderDisplayName =
@@ -741,6 +743,40 @@ export const Message = as<'div', MessageProps>(
       };
     }, [emojiBoard, handleKeyUp]);
 
+    useLayoutEffect(() => {
+      if (canSendReaction && emojiBoard) {
+        const emojiBoardPopoutComponent = document.getElementById('message_emoji-board_popout');
+        if (emojiBoardPopoutComponent) {
+          setBackdropEl(
+            createPortal(
+              <div
+                data-testid="custom-click-outside-backdrop"
+                style={{
+                  background: 'transparent',
+                  position: 'absolute',
+                  left: 0,
+                  zIndex: -1,
+                  width: '100vw',
+                  height: '100vh',
+                }}
+                aria-hidden="true"
+                onClick={() => {
+                  setEmojiBoard(false);
+                  closeMenu();
+                }}
+              />,
+              emojiBoardPopoutComponent
+            )
+          );
+        } else {
+          setBackdropEl(null);
+        }
+      } else {
+        setBackdropEl(null);
+      }
+      return () => setBackdropEl(null);
+    }, [emojiBoard, canSendReaction]);
+
     return (
       <MessageBase
         className={classNames(css.MessageBase, className)}
@@ -754,6 +790,7 @@ export const Message = as<'div', MessageProps>(
         {...focusWithinProps}
         ref={ref}
       >
+        {backdropEl}
         {!edit && (hover || menu || emojiBoard) && (
           <div className={css.MessageOptionsBase}>
             <Menu className={css.MessageOptionsBar} variant="SurfaceVariant">
@@ -764,10 +801,7 @@ export const Message = as<'div', MessageProps>(
                     position="Bottom"
                     align="End"
                     open={emojiBoard}
-                    onClick={() => {
-                      setEmojiBoard(false);
-                      closeMenu();
-                    }}
+                    id="message_emoji-board_popout"
                     content={
                       <EmojiBoard
                         imagePackRooms={imagePackRooms ?? []}


### PR DESCRIPTION
**Ticket**
https://momentify.atlassian.net/browse/MOM-1982 

**Resolution and changelog**
- [x] Update code for backdrop element for emoji board
- [x] Do not display member UUID in autocomplete mentions UI

**Screenshots**

<img width="514" alt="Screenshot 2024-05-13 at 8 10 41 PM" src="https://github.com/Momentify/momentify.cinny/assets/148766594/44a1bcca-d2ce-49f2-8e6b-600a1717ea5e">
<img width="2560" alt="Screenshot 2024-05-13 at 8 11 13 PM" src="https://github.com/Momentify/momentify.cinny/assets/148766594/017d281b-a81b-498d-a079-bc9cdc1c0166">

