### PR TITLE
MOM-1900 :zap: shorten displayed url to its origin string but keep original text as is elsewhere

### DIFF
--- a/src/app/organisms/room/RoomTimeline.tsx
+++ b/src/app/organisms/room/RoomTimeline.tsx
@@ -135,6 +135,7 @@ import initMatrix from '../../../client/initMatrix';
 import { useKeyDown } from '../../hooks/useKeyDown';
 import cons from '../../../client/state/cons';
 import { useDocumentFocusChange } from '../../hooks/useDocumentFocusChange';
+import { getUrlLinksInText } from './message/util';
 
 const TimelineFloat = as<'div', css.TimelineFloatVariants>(
   ({ position, className, ...props }, ref) => (
@@ -988,6 +989,16 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       const { body, formatted_body: customBody }: Record<string, unknown> =
         editedEvent?.getContent()['m.new_content'] ?? mEvent.getContent();
 
+      const bodyTextWithShortenedUrls = getUrlLinksInText(body as string).reduce<string>(
+        (acc, curr) => {
+          const { origin } = new URL(curr);
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          return acc.replaceAll(curr, origin);
+        },
+        body as string
+      );
+
       if (typeof body !== 'string') return null;
       return (
         <Text
@@ -998,7 +1009,10 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
           }}
           priority="400"
         >
-          {renderBody(body, typeof customBody === 'string' ? customBody : undefined)}
+          {renderBody(
+            bodyTextWithShortenedUrls,
+            typeof customBody === 'string' ? customBody : undefined
+          )}
           {!!editedEvent && <MessageEditedContent />}
         </Text>
       );

--- a/src/app/organisms/room/message/util.ts
+++ b/src/app/organisms/room/message/util.ts
@@ -26,7 +26,7 @@ export const getSrcFile = async (src: string): Promise<Blob> => {
   return blob;
 };
 
-export const getUrlLinksInText = (textBody: string): (string | null)[] =>
+export const getUrlLinksInText = (textBody: string): (string | URL)[] =>
   textBody
     .split(' ')
     .map((t) => t.match(URL_REGEX))


### PR DESCRIPTION
**Ticket**
https://momentify.atlassian.net/browse/MOM-1900

**Issue / request**
"It would be cool if we could hide some of the text url after displaying the preview. Maybe show just truncated to domain."

**Resolution / changelog**
In messages, shorten displayed URL to its origin string but keep original text as is elsewhere (e.g., for logic and functions).

**Screenshot**

<img width="413" alt="Screenshot 2024-05-20 at 9 29 43 PM" src="https://github.com/Momentify/momentify.cinny/assets/148766594/73caee32-44b5-44da-9ad5-8c3b1a9b38cb">

